### PR TITLE
Changes title to description in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-infinite-masonry",
-  "title": "React Native Masonry with Infinite Scrolling",
+  "description": "React Native Masonry with Infinite Scrolling",
   "version": "0.0.3",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
👋
When I ran `pod install` I received the error
```
[!] The `react-native-infinite-masonry` pod failed to validate due to 1 error:
    - ERROR | attributes: Missing required attribute `summary`.
```
So I took a look in the .podspec which have this line
`s.summary      = package["description"]`
 But `package.json` didn't have the description field so I changed the `title` field to `description`.
 